### PR TITLE
Handle sidecar-digest overrides when releasing from an ACR

### DIFF
--- a/test/onebox/multi-party-collab/encrypted-storage/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/encrypted-storage/run-scenario-generate-template-policy.ps1
@@ -418,8 +418,8 @@ az cleanroom governance contract vote `
 # }
 
 mkdir -p $outDir/deployments
-# Set overrides if local registry is to be used for clean room container images.
-if ($registry -eq "local") {
+# Set overrides if a non-mcr registry is to be used for clean room container images.
+if ($registry -ne "mcr") {
     $env:AZCLI_CLEANROOM_CONTAINER_REGISTRY_URL = $registryUrl
     $env:AZCLI_CLEANROOM_SIDECARS_VERSIONS_DOCUMENT_URL = "${registryUrl}/sidecar-digests:$registryTag"
 }

--- a/test/onebox/multi-party-collab/ml-training/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/ml-training/run-scenario-generate-template-policy.ps1
@@ -546,8 +546,8 @@ az cleanroom governance contract vote `
 # }
 
 mkdir -p $outDir/deployments
-# Set overrides if local registry is to be used for clean room container images.
-if ($registry -eq "local") {
+# Set overrides if a non-mcr registry is to be used for clean room container images.
+if ($registry -ne "mcr") {
     $env:AZCLI_CLEANROOM_CONTAINER_REGISTRY_URL = $registryUrl
     $env:AZCLI_CLEANROOM_SIDECARS_VERSIONS_DOCUMENT_URL = "${registryUrl}/sidecar-digests:$registryTag"
 }

--- a/test/onebox/multi-party-collab/nginx-hello/run-collab-aci.ps1
+++ b/test/onebox/multi-party-collab/nginx-hello/run-collab-aci.ps1
@@ -23,12 +23,9 @@ if ($registry -eq "mcr") {
     $usingRegistry = "mcr"
     $registryArg = "mcr"
 }
-else {
-    $registryArg = "local"
-    if ($registryUrl -eq "") {
-        throw "-registryUrl must be specified for acr option."
-    }
+if ($registry -eq "acr") {
     $usingRegistry = $registryUrl
+    $registryArg = "acr"
 }
 
 rm -rf $PSScriptRoot/generated

--- a/test/onebox/multi-party-collab/nginx-hello/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/nginx-hello/run-scenario-generate-template-policy.ps1
@@ -16,7 +16,7 @@ param
     [switch]
     $y,
 
-    [ValidateSet('mcr', 'local')]
+    [ValidateSet('mcr', 'local', 'acr')]
     [string]$registry = "local",
 
     [string]$registryUrl = "localhost:5001",
@@ -101,8 +101,8 @@ az cleanroom governance contract vote `
 
 
 mkdir -p $outDir/deployments
-# Set overrides if local registry is to be used for clean room container images.
-if ($registry -eq "local") {
+# Set overrides if a non-mcr registry is to be used for clean room container images.
+if ($registry -ne "mcr") {
     $env:AZCLI_CLEANROOM_CONTAINER_REGISTRY_URL = $registryUrl
     $env:AZCLI_CLEANROOM_SIDECARS_VERSIONS_DOCUMENT_URL = "${registryUrl}/sidecar-digests:$registryTag"
 }


### PR DESCRIPTION
Bringing over https://github.com/Azure/azure-cleanroom-private/pull/633