### PR TITLE
Move nightly BVTs to target a different ACR

### DIFF
--- a/.github/actions/release-ccf-network-containers/action.yml
+++ b/.github/actions/release-ccf-network-containers/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -44,6 +48,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -55,6 +60,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -66,6 +72,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -77,6 +84,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -88,3 +96,4 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}

--- a/.github/actions/release-ccf-network-security-policy/action.yml
+++ b/.github/actions/release-ccf-network-security-policy/action.yml
@@ -20,6 +20,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -45,3 +48,11 @@ runs:
           -repo ${{ inputs.registry-name }}.azurecr.io/${{ inputs.environment }}/cleanroom `
           -tag ${{ inputs.tag }} `
           -push
+
+    - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
+      with:
+        name: policies/ccf/ccf-network-security-policy
+        tag: ${{ inputs.tag }}
+        environment: ${{ inputs.environment }}
+        registry-name: ${{ inputs.registry-name }}

--- a/.github/actions/release-ccf-provider-client/action.yml
+++ b/.github/actions/release-ccf-provider-client/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,3 +36,4 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}

--- a/.github/actions/release-ccf-recovery-service-containers/action.yml
+++ b/.github/actions/release-ccf-recovery-service-containers/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -44,6 +48,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -55,6 +60,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -66,6 +72,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -77,3 +84,4 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}

--- a/.github/actions/release-ccf-recovery-service-security-policy/action.yml
+++ b/.github/actions/release-ccf-recovery-service-security-policy/action.yml
@@ -20,6 +20,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -45,3 +48,11 @@ runs:
           -repo ${{ inputs.registry-name }}.azurecr.io/${{ inputs.environment }}/cleanroom `
           -tag ${{ inputs.tag }} `
           -push
+
+    - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
+      with:
+        name: policies/ccf/ccf-recovery-service-security-policy
+        tag: ${{ inputs.tag }}
+        environment: ${{ inputs.environment }}
+        registry-name: ${{ inputs.registry-name }}

--- a/.github/actions/release-ccr-containers-version-document/action.yml
+++ b/.github/actions/release-ccr-containers-version-document/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
       run: pwsh ./.github/scripts/release-ccr-version-document.ps1 -tag ${{ inputs.tag }} -environment ${{ inputs.environment }} -registryName ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: versions/ccr-containers
         tag: latest

--- a/.github/actions/release-cgs-constitution-version-document/action.yml
+++ b/.github/actions/release-cgs-constitution-version-document/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
       run: pwsh ./.github/scripts/release-ccf-artefact-version-document.ps1 -containerName cgs-constitution -tag ${{ inputs.tag }} -environment ${{ inputs.environment }} -registryName ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: versions/cgs-constitution
         tag: latest

--- a/.github/actions/release-cgs-constitution/action.yml
+++ b/.github/actions/release-cgs-constitution/action.yml
@@ -20,6 +20,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -50,6 +53,7 @@ runs:
           --annotation "constitution.js.digest=sha256:$constitution_digest"
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: cgs-constitution
         tag: ${{ inputs.tag }}

--- a/.github/actions/release-cgs-js-app-version-document/action.yml
+++ b/.github/actions/release-cgs-js-app-version-document/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
       run: pwsh ./.github/scripts/release-ccf-artefact-version-document.ps1 -containerName cgs-js-app -tag ${{ inputs.tag }} -environment ${{ inputs.environment }} -registryName ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: versions/cgs-js-app
         tag: latest

--- a/.github/actions/release-cgs-js-app/action.yml
+++ b/.github/actions/release-cgs-js-app/action.yml
@@ -20,6 +20,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -49,6 +52,7 @@ runs:
           --annotation "bundle.json.digest=sha256:$bundle_digest"
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: cgs-js-app
         tag: ${{ inputs.tag }}

--- a/.github/actions/release-cleanroom-containers/action.yml
+++ b/.github/actions/release-cleanroom-containers/action.yml
@@ -22,6 +22,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -36,6 +39,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -47,6 +51,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -58,6 +63,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -69,6 +75,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -80,6 +87,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -91,6 +99,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -102,6 +111,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -113,6 +123,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -124,6 +135,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -135,6 +147,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -146,6 +159,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -157,3 +171,4 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id}}
+        needs-attestation: ${{ inputs.needs-attestation }}

--- a/.github/actions/release-container/action.yml
+++ b/.github/actions/release-container/action.yml
@@ -25,6 +25,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -77,7 +80,7 @@ runs:
         docker push ${{ inputs.registry-name }}.azurecr.io/${{ inputs.environment }}/cleanroom/${{ inputs.name }}:latest
 
     - uses: ./.github/actions/attest-artefact
-      if: ${{ steps.check-released-containers.outputs.container_released != 'true' }}
+      if: ${{ inputs.needs-attestation == 'true' && steps.check-released-containers.outputs.container_released != 'true' }}
       with:
         name: ${{ inputs.name }}
         tag: ${{ inputs.tag }}

--- a/.github/actions/release-governance-client-containers/action.yml
+++ b/.github/actions/release-governance-client-containers/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,7 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}
 
     - uses: ./.github/actions/release-container
       with:
@@ -44,3 +48,4 @@ runs:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        needs-attestation: ${{ inputs.needs-attestation }}

--- a/.github/actions/release-governance-client-version-documents/action.yml
+++ b/.github/actions/release-governance-client-version-documents/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -40,6 +43,7 @@ runs:
         ./.github/scripts/release-governance-client-version-documents.ps1 -tag ${{ inputs.tag }} -environment ${{ inputs.environment }} -registryName ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: versions/cgs-client
         tag: latest
@@ -47,6 +51,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: versions/cgs-ui
         tag: latest

--- a/.github/actions/release-sidecar-digests/action.yml
+++ b/.github/actions/release-sidecar-digests/action.yml
@@ -19,6 +19,9 @@ inputs:
   subscription-id:
     description: The subscription ID of the registry
     required: true
+  needs-attestation:
+    description: Whether the container needs attestation
+    required: true
 
 runs:
   using: composite
@@ -49,6 +52,7 @@ runs:
         overwrite: true
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/blobfuse-launcher-policy
         tag: ${{ inputs.tag }}
@@ -56,6 +60,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-attestation-policy
         tag: ${{ inputs.tag }}
@@ -63,6 +68,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-governance-policy
         tag: ${{ inputs.tag }}
@@ -70,6 +76,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-init-policy
         tag: ${{ inputs.tag }}
@@ -77,6 +84,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-secrets-policy
         tag: ${{ inputs.tag }}
@@ -84,6 +92,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-proxy-policy
         tag: ${{ inputs.tag }}
@@ -91,6 +100,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/ccr-proxy-ext-processor-policy
         tag: ${{ inputs.tag }}
@@ -98,6 +108,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/code-launcher-policy
         tag: ${{ inputs.tag }}
@@ -105,6 +116,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/identity-policy
         tag: ${{ inputs.tag }}
@@ -112,6 +124,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/otel-collector-policy
         tag: ${{ inputs.tag }}
@@ -119,6 +132,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: policies/skr-policy
         tag: ${{ inputs.tag }}
@@ -126,6 +140,7 @@ runs:
         registry-name: ${{ inputs.registry-name }}
 
     - uses: ./.github/actions/attest-artefact
+      if: ${{ inputs.needs-attestation == 'true' }}
       with:
         name: sidecar-digests
         tag: ${{ inputs.tag }}

--- a/.github/workflows/official_build.yml
+++ b/.github/workflows/official_build.yml
@@ -75,6 +75,7 @@ jobs:
         env:
           CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Build identity sidecar
         if: ${{ contains(inputs.build-type, 'cleanroom-containers') }}

--- a/.github/workflows/pr_cgs_tests.yml
+++ b/.github/workflows/pr_cgs_tests.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy CGS
         run: pwsh ./src/governance/test/deploy-cgs.ps1

--- a/.github/workflows/release-and-test.yml
+++ b/.github/workflows/release-and-test.yml
@@ -12,6 +12,15 @@ on:
         description: The release type
         type: string
         default: "cleanroom-containers, governance-client-containers, cgs-js-app, cgs-constitution, ccf-provider-client, ccf-network-containers, ccf-recovery-service-containers"
+      registry-name:
+        description: The registry name
+        required: false
+        type: string
+      needs-attestation:
+        description: Whether to attest released artefacts
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       tag:
@@ -22,6 +31,15 @@ on:
         description: The build type
         type: string
         default: "cleanroom-containers, governance-client-containers, cgs-js-app, cgs-constitution, ccf-provider-client, ccf-network-containers, ccf-recovery-service-containers"
+      registry-name:
+        description: The registry name
+        required: false
+        type: string
+      needs-attestation:
+        description: Whether to attest released artefacts
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -81,10 +99,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release sidecar digests
         if: ${{ contains(inputs.release-type, 'cleanroom-containers') }}
@@ -92,10 +111,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release governance client containers
         if: ${{ contains(inputs.release-type, 'governance-client-containers') }}
@@ -103,10 +123,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CGS JS App
         if: ${{ contains(inputs.release-type, 'cgs-js-app') }}
@@ -114,10 +135,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CGS constitution
         if: ${{ contains(inputs.release-type, 'cgs-constitution') }}
@@ -125,10 +147,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release ccr-containers version document
         if: ${{ contains(inputs.release-type, 'cleanroom-containers') }}
@@ -136,10 +159,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release constitution version document
         if: ${{ contains(inputs.release-type, 'cgs-constitution') }}
@@ -147,10 +171,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CGS JS app version document
         if: ${{ contains(inputs.release-type, 'cgs-js-app') }}
@@ -158,10 +183,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release version documents for governance client containers
         if: ${{ contains(inputs.release-type, 'governance-client-containers') }}
@@ -169,10 +195,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CCF provider client
         if: ${{ contains(inputs.release-type, 'ccf-provider-client') }}
@@ -180,10 +207,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CCF network containers
         if: ${{ contains(inputs.release-type, 'ccf-network-containers') }}
@@ -191,10 +219,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CCF recovery service containers
         if: ${{ contains(inputs.release-type, 'ccf-recovery-service-containers') }}
@@ -202,10 +231,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CCF network security policy
         if: ${{ contains(inputs.release-type, 'ccf-network-containers') }}
@@ -213,10 +243,11 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Release CCF recovery service security policy
         if: ${{ contains(inputs.release-type, 'ccf-recovery-service-containers') }}
@@ -224,18 +255,20 @@ jobs:
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          needs-attestation: ${{ inputs.needs-attestation }}
 
       - name: Verify attestation
+        if: ${{ inputs.needs-attestation }}
         uses: ./.github/actions/verify-attestation
         with:
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag}}
           release-type: ${{ inputs.release-type }}
           environment: internal
-          registry-name: ${{ vars.RELEASE_ACR_NAME }}
+          registry-name: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -245,7 +278,7 @@ jobs:
     needs: [build, release-to-test]
     environment: test
     env:
-      RELEASE_ACR_NAME: ${{ vars.RELEASE_ACR_NAME }}
+      RELEASE_ACR_NAME: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -281,7 +314,7 @@ jobs:
       - name: Run ml-training test
         uses: ./.github/actions/test-multi-party-collab/test-ml-training-caci
         with:
-          registry-url: ${{ vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
+          registry-url: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
           kvType: ${{ matrix.key-store }}
 
@@ -290,7 +323,7 @@ jobs:
     needs: [build, release-to-test]
     environment: test
     env:
-      RELEASE_ACR_NAME: ${{ vars.RELEASE_ACR_NAME }}
+      RELEASE_ACR_NAME: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -317,7 +350,7 @@ jobs:
       - name: Run encrypted-storage test
         uses: ./.github/actions/test-multi-party-collab/test-encrypted-storage-caci
         with:
-          registry-url: ${{ vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
+          registry-url: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
 
   bvt-nginx-hello:
@@ -325,7 +358,7 @@ jobs:
     needs: [build, release-to-test]
     environment: test
     env:
-      RELEASE_ACR_NAME: ${{ vars.RELEASE_ACR_NAME }}
+      RELEASE_ACR_NAME: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -352,7 +385,7 @@ jobs:
       - name: Run nginx-hello test
         uses: ./.github/actions/test-multi-party-collab/test-nginx-hello-caci
         with:
-          registry-url: ${{ vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
+          registry-url: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
           tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}
 
   # bvt-triton-inference:
@@ -360,7 +393,7 @@ jobs:
   #   needs: [build, release-to-test]
   #   environment: test
   #   env:
-  #     RELEASE_ACR_NAME: ${{ vars.RELEASE_ACR_NAME }}
+  #     RELEASE_ACR_NAME: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}
   #     AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
   #     AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
   #     AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -387,5 +420,5 @@ jobs:
   #     - name: Run triton-inference test
   #       uses: ./.github/actions/test-multi-party-collab/test-triton-inference-caci
   #       with:
-  #         registry-url: ${{ vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
+  #         registry-url: ${{ inputs.registry-name || vars.RELEASE_ACR_NAME }}.azurecr.io/internal/cleanroom
   #         tag: ${{ inputs.tag || steps.get-short-commit-hash.outputs.tag }}

--- a/.github/workflows/release-and-test.yml
+++ b/.github/workflows/release-and-test.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Create file to track released containers
         run: touch released-containers-internal.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       release-type: ${{ inputs.release-type }}
+      needs-attestation: true
+      registry-name: ${{ secrets.RELEASE_ACR_NAME }}
 
   # Add release specific tests here
   release-tests:


### PR DESCRIPTION
Enabling support for nightly BVT runs to target a different ACR so as not to pollute MCR-onboarded images.