### PR TITLE
Allow specifying `--provider_client` in `ccf network up`

### DIFF
--- a/src/tools/azure-cli-extension/cleanroom/azext_cleanroom/custom.py
+++ b/src/tools/azure-cli-extension/cleanroom/azext_cleanroom/custom.py
@@ -2074,6 +2074,7 @@ def ccf_network_up_cmd(
     location,
     security_policy_creation_option,
     recovery_mode,
+    provider_client_name,
 ):
     from .custom_ccf import ccf_network_up
 
@@ -2086,6 +2087,7 @@ def ccf_network_up_cmd(
         location,
         security_policy_creation_option,
         recovery_mode,
+        provider_client_name,
     )
 
 

--- a/src/tools/azure-cli-extension/cleanroom/azext_cleanroom/custom_ccf.py
+++ b/src/tools/azure-cli-extension/cleanroom/azext_cleanroom/custom_ccf.py
@@ -126,6 +126,7 @@ def ccf_network_up(
     location,
     security_policy_creation_option,
     recovery_mode,
+    provider_client_name
 ):
     if not location:
         location = az_cli(
@@ -230,7 +231,6 @@ def ccf_network_up(
     with open(provider_config_file, "w") as f:
         f.write(json.dumps(provider_config, indent=2))
 
-    provider_client_name = "ccf-provider"
     az_cli(f"cleanroom ccf provider deploy --name {provider_client_name}")
 
     recovery_service_name = ""


### PR DESCRIPTION
This allows the user to run multiple ccf-providers in parallel, which is useful for testing which brings up infrastructure