### PR TITLE
Update setup-access.ps1

### DIFF
--- a/test/onebox/multi-party-collab/setup-access.ps1
+++ b/test/onebox/multi-party-collab/setup-access.ps1
@@ -286,7 +286,8 @@ else {
       --identity-name $MANAGED_IDENTITY_NAME `
       --resource-group $resourceGroup `
       --issuer $issuerUrl `
-      --subject $contractId
+      --subject $contractId `
+      --audience api://AzureADTokenExchange
   }
   else {
     $parameters = @{


### PR DESCRIPTION
AZ CLI 2.74 introduced a breaking change in `az identity federated-credential create` which requires a `--audience` to be specified.

Issue link: https://github.com/azure/azure-cli/issues/31598