### PR TITLE
Missed adding confcom version in release flow.

### DIFF
--- a/.github/actions/release-ccf-network-security-policy/action.yml
+++ b/.github/actions/release-ccf-network-security-policy/action.yml
@@ -42,6 +42,12 @@ runs:
     - shell: pwsh
       run: Install-Module -Name powershell-yaml -Force
 
+    - name: Install confcom extension
+      shell: pwsh
+      run: |
+        az extension add --name confcom --version 1.2.4 -y --allow-preview true
+        az version
+
     - shell: pwsh
       run: |
         ./build/build-ccf-network-security-policy.ps1 `

--- a/.github/actions/release-ccf-recovery-service-security-policy/action.yml
+++ b/.github/actions/release-ccf-recovery-service-security-policy/action.yml
@@ -42,6 +42,12 @@ runs:
     - shell: pwsh
       run: Install-Module -Name powershell-yaml -RequiredVersion 0.4.7 -Force
 
+    - name: Install confcom extension
+      shell: pwsh
+      run: |
+        az extension add --name confcom --version 1.2.4 -y --allow-preview true
+        az version
+
     - shell: pwsh
       run: |
         ./build/build-ccf-recovery-service-security-policy.ps1 `

--- a/.github/actions/release-sidecar-digests/action.yml
+++ b/.github/actions/release-sidecar-digests/action.yml
@@ -41,6 +41,12 @@ runs:
     - shell: pwsh
       run: Install-Module -Name powershell-yaml -RequiredVersion 0.4.7 -Force
 
+    - name: Install confcom extension
+      shell: pwsh
+      run: |
+        az extension add --name confcom --version 1.2.4 -y --allow-preview true
+        az version
+
     - shell: pwsh
       run: |
         ./build/build-ccr-digests.ps1 -repo ${{ inputs.registry-name }}.azurecr.io/${{ inputs.environment }}/azurecleanroom -tag ${{ inputs.tag }} -push

--- a/.github/workflows/release-and-test-nightly-trigger.yml
+++ b/.github/workflows/release-and-test-nightly-trigger.yml
@@ -4,6 +4,7 @@ run-name: Nightly test - ${{ github.sha }}
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   nightly-test:

--- a/.github/workflows/release-and-test-nightly-trigger.yml
+++ b/.github/workflows/release-and-test-nightly-trigger.yml
@@ -4,7 +4,6 @@ run-name: Nightly test - ${{ github.sha }}
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
 
 jobs:
   nightly-test:


### PR DESCRIPTION
The confcom version used in the release flow was not pegged to 1.2.4 leading to failures. There was no separate step for installing the confcom extension in those flows, hence latest was getting picked.