### PR TITLE
Fix frontend service security policy attestation path mismatch

### DIFF
--- a/.github/actions/release-frontend-service-security-policy/action.yml
+++ b/.github/actions/release-frontend-service-security-policy/action.yml
@@ -58,7 +58,7 @@ runs:
     - uses: ./.github/actions/attest-artefact
       if: ${{ inputs.needs-attestation == 'true' }}
       with:
-        name: policies/frontend-service-security-policy
+        name: policies/workloads/frontend-service-security-policy
         tag: ${{ inputs.tag }}
         environment: ${{ inputs.environment }}
         registry-name: ${{ inputs.registry-name }}


### PR DESCRIPTION
- Updated `.github/actions/release-frontend-service-security-policy/action.yml`
- Changed attest artifact name from `policies/frontend-service-security-policy` to `policies/workloads/frontend-service-security-policy`