### PR TITLE
Update ACR image digests after cleanroomdev-rg recovery

### DIFF
--- a/test/onebox/multi-party-collab/encrypted-storage/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/encrypted-storage/run-scenario-generate-template-policy.ps1
@@ -327,7 +327,7 @@ $sample_code = $(cat $PSScriptRoot/consumer/application/main.go | base64 -w 0)
 az cleanroom config add-application `
     --cleanroom-config $consumerConfig `
     --name demo-app `
-    --image "cleanroomsamplesprivate.azurecr.io/golang@sha256:4304d944c421bb279ad1faada14d03ac7e7edca61793d2f6a7ad94681c457887" `
+    --image "cleanroomsamplesprivate.azurecr.io/golang@sha256:7095ad02810845fa35d1fb090b8e57dd20dce4ca36b29b42951802350d2ec90e" `
     --command "bash -c 'echo `$CODE | base64 -d > main.go; go run main.go'" `
     --datasources "publisher-input=/mnt/remote/input" `
     --datasinks "consumer-output=/mnt/remote/output" `

--- a/test/onebox/multi-party-collab/ml-training/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/ml-training/run-scenario-generate-template-policy.ps1
@@ -486,7 +486,7 @@ az cleanroom config add-datasink `
 az cleanroom config add-application `
     --cleanroom-config $tdcConfig `
     --name depa-training `
-    --image "cleanroomsamples.azurecr.io/depa-training@sha256:58cc4180bbfac4fd6f981b476c5cad6702ac3474b09424d6305bbd62c40a37fb" `
+    --image "cleanroomsamples.azurecr.io/depa-training@sha256:e3be41ded455696dbc6186e77a135a0dadd3cf287df16ba532b7411077878a4c" `
     --command "/bin/bash run.sh" `
     --datasources "config=/mnt/remote/config" `
     "cowin=/mnt/remote/cowin" `

--- a/test/onebox/multi-party-collab/nginx-hello/run-scenario-generate-template-policy.ps1
+++ b/test/onebox/multi-party-collab/nginx-hello/run-scenario-generate-template-policy.ps1
@@ -156,7 +156,7 @@ az cleanroom config add-application `
     --memory 4
 
 # Use a pre-built policy bundle if the registry is 'mcr'.
-$policyBundleUrl = "cleanroomsamples.azurecr.io/nginx-hello/nginx-hello-policy@sha256:6c2133e896121f753964ec42d91bee3308dd6887279f3246137868d569c3d812"
+$policyBundleUrl = "cleanroomsamples.azurecr.io/nginx-hello/nginx-hello-policy@sha256:bb42b62f2e773d92835a9f6d4ecea6b7b3fc3fd2be2092454d6ae717de6ff885"
 if ($registry -ne "mcr") {
     pwsh $PSScriptRoot/build-policy-bundle.ps1 -tag $tag -repo $repo
     $policyBundleUrl = "${repo}/nginx-hello-policy:$tag"


### PR DESCRIPTION
The cleanroomdev-rg resource group was deleted by the cleanup pipeline (cleanroom-emu-pr-mi) because it lacked the SkipCleanup tag. The ACR (cleanroomsamples, cleanroomsamplesprivate) and all images were lost.

This commit updates the SHA digests for rebuilt images:
- depa-training: rebuilt from source (Dockerfile.train)
- nginx-hello-policy: rebuilt via OPA bundle
- golang: re-pulled from Docker Hub