### PR TITLE
Run fixes and release workflow artifact path correction.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -706,7 +706,7 @@ jobs:
         if: ${{ contains(inputs.release-type, 'cleanroom-containers') }}
         run: |
           gh release upload ${{ inputs.tag }} \
-          ${{ steps.download-ccr-artefacts.outputs.download-path }}/ccr-artefacts-unlisted/ccr-governance-opa-policy.tar.gz
+          ${{ steps.download-ccr-artefacts.outputs.download-path }}/ccr-governance-opa-policy.tar.gz
 
       # TODO (anrdesai): Re-add cleanroom-client.tar attachment to the release once we figure out a way to make it smaller than 2GB.
       - name: Upload cleanroom-client assets

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,14 +39,14 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.9.28" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OrasProject.Oras" Version="0.4.0" />
     <PackageVersion Include="Polly" Version="8.6.5" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
Fix release artifact upload path — Corrects the ccr-governance-opa-policy.tar.gz upload path in the release workflow by removing the extra ccr-artefacts-unlisted/ subdirectory from the artifact path.