### PR TITLE
feat: enable OpenTelemetry for frontend-service and ccf-consortium-ma…

### DIFF
--- a/src/ccf/consortium-manager/ccf-consortium-manager/Startup.cs
+++ b/src/ccf/consortium-manager/ccf-consortium-manager/Startup.cs
@@ -20,7 +20,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/workloads/frontend/Startup.cs
+++ b/src/workloads/frontend/Startup.cs
@@ -17,7 +17,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/workloads/frontend/helmchart/templates/deployment.yaml
+++ b/src/workloads/frontend/helmchart/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
               value: {{ .Values.ccrProxy.serviceCertOutputFile | quote }}
             - name: SKR_PORT
               value: {{ .Values.skr.port | quote }}
+            {{- if .Values.frontendService.otelEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.frontendService.otelEndpoint | quote }}
+            {{- end }}
         - name: cgs-client
           {{- with .Values.securityContext }}
           securityContext:

--- a/src/workloads/frontend/helmchart/values.yaml
+++ b/src/workloads/frontend/helmchart/values.yaml
@@ -98,6 +98,9 @@ frontendService:
   firstPartyAppTokenScope: "FIRST_PARTY_APP_TOKEN_SCOPE"
   # Azure AD tenant ID.
   tenantId: "TENANT_ID"
+  # OTLP endpoint for OpenTelemetry logs/traces/metrics (e.g. http://geneva-otlp:4317).
+  # Leave empty to disable OTLP export.
+  otelEndpoint: ""
 
 # SKR (Secure Key Release) sidecar configuration for attestation.
 skr:


### PR DESCRIPTION
…nager

Enable OTLP exporter for confidential container logging. These services run on CACI where MDSD sidecars cannot be used. With EnableOpenTelemetry=true, the ApiStartup OTel pipeline registers OTLP gRPC exporter that sends logs/traces/metrics over the network to the OTLP endpoint.

Changes:
- frontend Startup.cs: EnableOpenTelemetry => true
- ccf-consortium-manager Startup.cs: EnableOpenTelemetry => true
- frontend helmchart: add configurable otelEndpoint value (OTEL_EXPORTER_OTLP_ENDPOINT env var, only set when non-empty)
- frontend values.yaml: add frontendService.otelEndpoint (default empty)

No Geneva sidecar is needed inside the confidential pod. The OTLP endpoint is configured via helm values per environment.