### PR TITLE
feat: enable OpenTelemetry for all RP client services and frontend/CM

### DIFF
--- a/src/ccf/ccf-provider-client/Startup.cs
+++ b/src/ccf/ccf-provider-client/Startup.cs
@@ -17,7 +17,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/ccf/consortium-manager/ccf-consortium-manager/Startup.cs
+++ b/src/ccf/consortium-manager/ccf-consortium-manager/Startup.cs
@@ -20,7 +20,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/cleanroom-cluster/cleanroom-cluster-provider-client/Startup.cs
+++ b/src/cleanroom-cluster/cleanroom-cluster-provider-client/Startup.cs
@@ -15,7 +15,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/governance/client/Startup.cs
+++ b/src/governance/client/Startup.cs
@@ -13,7 +13,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/internal/restapi-common/ApiStartup.cs
+++ b/src/internal/restapi-common/ApiStartup.cs
@@ -44,8 +44,7 @@ public abstract class ApiStartup
             {
                 builder.AddOpenTelemetry(options =>
                 {
-                    options.SetResourceBuilder(ResourceBuilder.CreateDefault()
-                        .AddService(this.OTelServiceName ?? this.ServiceName));
+                    options.SetResourceBuilder(this.CreateResourceBuilder());
                     options.AddOtlpExporter();
                 });
             }
@@ -86,9 +85,7 @@ public abstract class ApiStartup
                 .WithTracing(tracing =>
                 {
                     tracing
-                        .SetResourceBuilder(
-                            ResourceBuilder.CreateDefault()
-                                .AddService(this.OTelServiceName ?? this.ServiceName))
+                        .SetResourceBuilder(this.CreateResourceBuilder())
                         .AddAspNetCoreInstrumentation()
                         .AddHttpClientInstrumentation()
                         .AddProcessor(new BaggageSpanProcessor())
@@ -97,9 +94,7 @@ public abstract class ApiStartup
                 .WithMetrics(metrics =>
                 {
                     metrics
-                        .SetResourceBuilder(
-                            ResourceBuilder.CreateDefault()
-                                .AddService(this.OTelServiceName ?? this.ServiceName))
+                        .SetResourceBuilder(this.CreateResourceBuilder())
                         .AddAspNetCoreInstrumentation()
                         .AddHttpClientInstrumentation()
                         .AddMeter(this.OTelServiceName ?? this.ServiceName)
@@ -136,5 +131,23 @@ public abstract class ApiStartup
 
     public virtual void OnConfigure(WebApplication app, IWebHostEnvironment env)
     {
+    }
+
+    private ResourceBuilder CreateResourceBuilder()
+    {
+        var serviceName = this.OTelServiceName ?? this.ServiceName;
+        var builder = ResourceBuilder.CreateDefault()
+            .AddService(serviceName);
+
+        var deploymentName = Environment.GetEnvironmentVariable("DEPLOYMENT_NAME");
+        if (!string.IsNullOrEmpty(deploymentName))
+        {
+            builder.AddAttributes(new Dictionary<string, object>
+            {
+                ["k8s.deployment.name"] = deploymentName
+            });
+        }
+
+        return builder;
     }
 }

--- a/src/workloads/frontend/Startup.cs
+++ b/src/workloads/frontend/Startup.cs
@@ -17,7 +17,7 @@ internal class Startup : ApiStartup
     {
     }
 
-    public override bool EnableOpenTelemetry => false;
+    public override bool EnableOpenTelemetry => true;
 
     public override void OnConfigureServices(IServiceCollection services)
     {

--- a/src/workloads/frontend/helmchart/templates/deployment.yaml
+++ b/src/workloads/frontend/helmchart/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             {{- if .Values.frontendService.otelEndpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.frontendService.otelEndpoint | quote }}
+            - name: DEPLOYMENT_NAME
+              value: "frontend-service"
             {{- end }}
         - name: cgs-client
           {{- with .Values.securityContext }}
@@ -107,6 +109,8 @@ spec:
               value: {{ .Values.frontendService.otelEndpoint | quote }}
             - name: CGS_CLIENT_ENABLE_OPEN_TELEMETRY
               value: "true"
+            - name: DEPLOYMENT_NAME
+              value: "cgs-client"
             {{- end }}
             {{- with .Values.cgsClient.env }}
             {{- toYaml . | nindent 12 }}

--- a/src/workloads/frontend/helmchart/templates/deployment.yaml
+++ b/src/workloads/frontend/helmchart/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
               value: {{ .Values.ccrProxy.serviceCertOutputFile | quote }}
             - name: SKR_PORT
               value: {{ .Values.skr.port | quote }}
+            {{- if .Values.frontendService.otelEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.frontendService.otelEndpoint | quote }}
+            {{- end }}
         - name: cgs-client
           {{- with .Values.securityContext }}
           securityContext:

--- a/src/workloads/frontend/helmchart/templates/deployment.yaml
+++ b/src/workloads/frontend/helmchart/templates/deployment.yaml
@@ -101,10 +101,16 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.cgsClient.env }}
           env:
+            {{- if .Values.frontendService.otelEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.frontendService.otelEndpoint | quote }}
+            - name: CGS_CLIENT_ENABLE_OPEN_TELEMETRY
+              value: "true"
+            {{- end }}
+            {{- with .Values.cgsClient.env }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
         {{- if .Values.skr.enabled }}
         - name: skr
           image: {{ .Values.skr.image | quote }}

--- a/src/workloads/frontend/helmchart/values.yaml
+++ b/src/workloads/frontend/helmchart/values.yaml
@@ -98,6 +98,9 @@ frontendService:
   firstPartyAppTokenScope: "FIRST_PARTY_APP_TOKEN_SCOPE"
   # Azure AD tenant ID.
   tenantId: "TENANT_ID"
+  # OTLP endpoint for OpenTelemetry logs/traces/metrics (e.g. http://geneva-otlp:4317).
+  # Leave empty to disable OTLP export.
+  otelEndpoint: ""
 
 # SKR (Secure Key Release) sidecar configuration for attestation.
 skr:


### PR DESCRIPTION
Enable OTLP exporter for:
- frontend-service (confidential, CACI)
- ccf-consortium-manager (confidential, CACI)
- cgs-client (AKS)
- ccf-provider-client (AKS)
- cleanroom-cluster-provider-client (AKS)

With EnableOpenTelemetry=true, the ApiStartup OTel pipeline registers Console + OTLP + Geneva (if enabled) exporters for logs/traces/metrics.

Frontend helmchart: add configurable otelEndpoint value (OTEL_EXPORTER_OTLP_ENDPOINT env var, only set when non-empty).

Confidential containers send logs via OTLP gRPC over the network. AKS pods send logs via Geneva exporter through the MDSD unix socket. No Geneva sidecar needed inside confidential pods.